### PR TITLE
Improve time formatting in progress bar and download summary

### DIFF
--- a/src/download_summary.py
+++ b/src/download_summary.py
@@ -1,5 +1,6 @@
 import time
 import logging
+from utils import format_eta
 
 class DownloadSummary:
     def __init__(self, message, file_info, download_dir, start_time, end_time, file_size, origin_group, user_id=None, channel_id=None, status='downloading', download_type='file'):
@@ -38,7 +39,7 @@ class DownloadSummary:
                     f"**Download Folder:** {self.download_dir}\n"
                     f"**Start Time:** {time.strftime('%H:%M:%S', time.localtime(self.start_time))}\n"
                     f"**End Time:** {time.strftime('%H:%M:%S', time.localtime(self.end_time))}\n"
-                    f"**Download Time:** {download_time:.2f} seconds\n"
+                    f"**Download Time:** {format_eta(download_time)}\n"
                     f"**User ID:** {self.user_id}"
                 )
             elif self.download_type == 'link':
@@ -49,7 +50,7 @@ class DownloadSummary:
                     f"**File Size:** {self.file_size / (1024*1024):.2f} MB\n"
                     f"**Start Time:** {time.strftime('%H:%M:%S', time.localtime(self.start_time))}\n"
                     f"**End Time:** {time.strftime('%H:%M:%S', time.localtime(self.end_time))}\n"
-                    f"**Download Time:** {download_time:.2f} seconds\n"
+                    f"**Download Time:** {format_eta(download_time)}\n"
                     f"**Download Speed:** {download_speed / 1024:.2f} KB/s\n"
                     f"**User Id:** {self.user_id}"
                 )
@@ -61,14 +62,14 @@ class DownloadSummary:
                     f"**File Size:** {self.file_size / (1024*1024):.2f} MB\n"
                     f"**Start Time:** {time.strftime('%H:%M:%S', time.localtime(self.start_time))}\n"
                     f"**End Time:** {time.strftime('%H:%M:%S', time.localtime(self.end_time))}\n"
-                    f"**Download Time:** {download_time:.2f} seconds\n"
+                    f"**Download Time:** {format_eta(download_time)}\n"
                     f"**Download Speed:** {download_speed / 1024:.2f} KB/s\n"
                     f"**User Id:** {self.user_id}\n"
                     f"**Origin Group:** {self.origin_group}"
                 )
 
             if self.channel_id:
-                summary_text += f"\nChannel ID: {self.channel_id}"
+                summary_text += f"\n**Channel ID:** {self.channel_id}"
 
             return summary_text
         except Exception as e:

--- a/src/progress_bar.py
+++ b/src/progress_bar.py
@@ -4,7 +4,7 @@ import asyncio # Temporary import for debugging
 
 
 def format_eta(seconds: float) -> str:
-    total_seconds = int(seconds)
+    total_seconds = max(0, int(seconds))
     hours = total_seconds // 3600
     minutes = (total_seconds % 3600) // 60
     secs = total_seconds % 60

--- a/src/progress_bar.py
+++ b/src/progress_bar.py
@@ -1,20 +1,7 @@
 import time
 from telethon.tl.types import KeyboardButtonCallback, ReplyInlineMarkup
 import asyncio # Temporary import for debugging
-
-
-def format_eta(seconds: float) -> str:
-    total_seconds = max(0, int(seconds))
-    hours = total_seconds // 3600
-    minutes = (total_seconds % 3600) // 60
-    secs = total_seconds % 60
-
-    if hours > 0:
-        return f"{hours}h {minutes}m {secs}s"
-    if minutes > 0:
-        return f"{minutes}m {secs}s"
-    return f"{secs}s"
-
+from utils import format_eta
 
 class ProgressBar:
     def __init__(self, initial_message, file_info, logger, download_dir, file_size, start_time, origin_group, user_id, progress_status_show, channel_id=None, cancellation_flag=None):

--- a/src/progress_bar.py
+++ b/src/progress_bar.py
@@ -65,7 +65,7 @@ class ProgressBar:
                 )
 
                 if self.channel_id:
-                    progress_text += f"\nChannel ID: {self.channel_id}"
+                    progress_text += f"\n**Channel ID:** {self.channel_id}"
                 
                 buttons = ReplyInlineMarkup([[
                     KeyboardButtonCallback("Cancel Download", data=f"cancel_download_{self.initial_message.id}".encode('utf-8'))

--- a/src/progress_bar.py
+++ b/src/progress_bar.py
@@ -2,6 +2,20 @@ import time
 from telethon.tl.types import KeyboardButtonCallback, ReplyInlineMarkup
 import asyncio # Temporary import for debugging
 
+
+def format_eta(seconds: float) -> str:
+    total_seconds = int(seconds)
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+    secs = total_seconds % 60
+
+    if hours > 0:
+        return f"{hours}h {minutes}m {secs}s"
+    if minutes > 0:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"
+
+
 class ProgressBar:
     def __init__(self, initial_message, file_info, logger, download_dir, file_size, start_time, origin_group, user_id, progress_status_show, channel_id=None, cancellation_flag=None):
         self.initial_message = initial_message
@@ -45,7 +59,7 @@ class ProgressBar:
                     f"**Start Time:** {time.strftime('%H:%M:%S', time.localtime(self.start_time))}\n"
                     f"**Progress:** {current / (1024*1024):.2f}MB / {total / (1024*1024):.2f}MB ({percentage:.2f}%)\n"
                     f"**Speed:** {speed / (1024*1024):.2f}MB/s\n"
-                    f"**ETA:** {eta:.0f}s\n"
+                    f"**ETA:** {format_eta(eta)}\n"
                     f"**User Id:** {self.user_id}\n"
                     f"**Origin Group:** {self.origin_group}"
                 )

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,11 @@
+def format_eta(seconds: float) -> str:
+    total_seconds = max(0, int(seconds))
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+    secs = total_seconds % 60
+
+    if hours > 0:
+        return f"{hours}h {minutes}m {secs}s"
+    if minutes > 0:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"


### PR DESCRIPTION
## Improve time formatting in progress bar and download summary

Duration fields were displayed as raw seconds (e.g. `2593s`, `355.49 seconds`), making them hard to read at a glance.

### Changes

Added a shared `utils.py` module with a `format_eta()` helper function that converts seconds into a human-readable format:

- `15s`
- `1m 15s`
- `1h 30m 30s`

Negative values are clamped to zero via `max(0, ...)` to prevent edge cases where `current > total` could produce a negative ETA.

`format_eta()` is now used in:
- `progress_bar.py` — **ETA** field during download
- `download_summary.py` — **Download Time** field in the completion message (file, youtube and link types)

Also fixed missing bold formatting on the `Channel ID` field in both `progress_bar.py` and `download_summary.py`, which was appended via string concatenation without the `**` markers.

### Before / After

| Field | Before | After |
|-------|--------|-------|
| `ETA` | `2593s` | `43m 13s` |
| `Download Time` | `355.49 seconds` | `5m 55s` |
| `Channel ID` | `Channel ID: 123456` | `**Channel ID:** 123456` |